### PR TITLE
Move Google CTF results to hall.md from hackathons.md

### DIFF
--- a/fame.md
+++ b/fame.md
@@ -46,6 +46,12 @@ title:  ICC Hall of Fame
             <td> 5th place </td>
             <td>  Ian Madden, Scott </td>
         </tr>
+        <tr>
+            <td>Last Placers</td>
+            <td><a href="https://capturetheflag.withgoogle.com/">Google CTF 2021</a></td>
+            <td>Cameron Weng, Ajitesh Bhatti, Scott Chiang, Melody Yu, Agam Randhawa, Tom Tim, David Zhang, Kai Wang, Timothy Chen, and two other unnamed competitors</td>
+            <td>Tied for 231st place</td>
+        </tr>
         <!-- and so on... -->
     </tbody>
 </table>

--- a/hackathons.md
+++ b/hackathons.md
@@ -30,12 +30,6 @@ Small projects can make big impacts to our world. ICC proudly presents to you th
             <td>Ian Madden, Melody Yu, Agam Randhawa, Sophia Dai</td>
             <td>None</td>
         </tr>
-        <tr>
-            <td>Last Placers</td>
-            <td><a href="https://capturetheflag.withgoogle.com/">Google CTF 2021</a></td>
-            <td>Cameron Weng, Ajitesh Bhatti, Scott Chiang, Melody Yu, Agam Randhawa, Tom Tim, David Zhang, Kai Wang, Timothy Chen, and two other unnamed competitors</td>
-            <td>Tied for 231st place</td>
-        </tr>
     </tbody>
 </table>
 

--- a/hackathons.md
+++ b/hackathons.md
@@ -31,7 +31,7 @@ Small projects can make big impacts to our world. ICC proudly presents to you th
             <td>None</td>
         </tr>
         <tr>
-            <td><a href="https://geocases.irvinecoding.club">Last Placers</a></td>
+            <td>Last Placers</td>
             <td><a href="https://capturetheflag.withgoogle.com/">Google CTF 2021</a></td>
             <td>Cameron Weng, Ajitesh Bhatti, Scott Chiang, Melody Yu, Agam Randhawa, Tom Tim, David Zhang, Kai Wang, Timothy Chen, and two other unnamed competitors</td>
             <td>Tied for 231st place</td>


### PR DESCRIPTION
The Google CTF results should probably be in hall.md instead of hackathons.md. Also the team name linked to GeoCases which I removed.